### PR TITLE
Remove 1.x branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,6 @@
             "SilverStripe\\EventDispatcher\\Tests\\": "tests/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.x-dev"
-        }
-    },
     "scripts": {
         "lint": "vendor/bin/phpcs src/ tests/",
         "lint-clean": "vendor/bin/phpcbf src/ tests/"


### PR DESCRIPTION
This module isn't stable yet, we don't have a "0" branch, and a bunch of 0.1.x tags. Aliasing `1.x-dev` already doesn't seem to serve any purpose. The two dependants called out in Packagist use `dev-master` and `^0.1` constraints, so this shouldn't break anything.

https://github.com/silverstripe/silverstripe-graphql/blob/3/composer.json
https://github.com/silverstripe/silverstripe-cms-events/blob/master/composer.json